### PR TITLE
Fix support for background colors in code blocks

### DIFF
--- a/blogdown/modules/pygments.py
+++ b/blogdown/modules/pygments.py
@@ -52,7 +52,7 @@ def write_stylesheet(builder, **kwargs):
 def setup(builder):
     global html_formatter
     style = get_style_by_name(builder.config.root_get('modules.pygments.style'))
-    html_formatter = HtmlFormatter(style=style)
+    html_formatter = HtmlFormatter(style=style, cssclass='hll')
     directives.register_directive('code-block', CodeBlock)
     directives.register_directive('sourcecode', CodeBlock)
     before_file_processed.connect(inject_stylesheet)


### PR DESCRIPTION
Hey, first of all: I started to use blogdown rather than rstblog, because I
like the availability as a PyPI package and I'm hoping that you are more
active than the original, i.e. you react to pull-requests and issues.

When changing the pygments style, I noticed that background colors fail to
work. This is because the class of the wrapping html element doesn't match
the class for background color in the css.

I have already [reported this issue](https://bitbucket.org/birkenfeld/pygments-main/issue/1110/default-css-classes-dont-match) upstream.
If they decide not to address this issue, it would be nice to fix it inside
this repository and do a new micro release. Even if they do fix it, I think
it's worth to include the patch in order to support old pygments versions.